### PR TITLE
:ambulance: Fixes CD issue in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ defaults: &defaults
                   --git \
                   --image "hassioaddons/base-{arch}" \
                   --target ${ARCH} \
-                  --${ARCH}
+                  --${ARCH} \
                   --push
               else
                 docker run \


### PR DESCRIPTION
# Proposed Changes

Fixes an issue with CD in CircleCI.
Currently causes the push to Docker Hub to fail.

## Related Issues

None