### PR TITLE
:sparkles: Added bash to the base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -20,6 +20,7 @@ RUN \
         tar \
     \
     && apk add --no-cache \
+        bash \
         ca-certificates \
         eudev \
         jq \


### PR DESCRIPTION
# Proposed Changes

Added `bash` to the base image, to remain compatible with the current Home Assistant base images.

## Related Issues

None