### PR TITLE
Added extra debug output when curl API call fails

### DIFF
--- a/base/rootfs/usr/lib/hassio-addons/modules/api.sh
+++ b/base/rootfs/usr/lib/hassio-addons/modules/api.sh
@@ -52,10 +52,11 @@ hass.api.call() {
 
     hass.log.trace "${FUNCNAME[0]}" "$@"
 
-    if ! response=$(curl --silent \
+    if ! response=$(curl --silent --show-error \
         --write-out '\n%{http_code}' --request "${method}" \
         "${HASS_API_ENDPOINT}${resource}"
     ); then
+        hass.log.debug "${response}"
         hass.log.error "Something went wrong contacting the API"
         return "${EX_NOK}"
     fi


### PR DESCRIPTION
# Proposed Changes

Currently, when a `curl` API call fails, there is no way to tell what went wrong.
This PR adds extra debug logging when this happens.

## Related Issues

#9