### PR TITLE
Upgrades to Alpine 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning][semantic-versioning].
 
 ## Unreleased
 
-No unreleased changes yet.
+### Changed
+
+- Upgraded to Alpine 3.7
 
 ## [v1.1.0] (2017-11-15)
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=alpine:3.6
+ARG BUILD_FROM=alpine:3.7
 FROM ${BUILD_FROM}
 
 # Environment variables

--- a/base/build.json
+++ b/base/build.json
@@ -2,10 +2,10 @@
     "image": "hassioaddons/base-{arch}",
     "squash": true,
     "build_from": {
-        "aarch64": "arm64v8/alpine:3.6",
-        "amd64": "alpine:3.6",
-        "armhf": "arm32v6/alpine:3.6",
-        "i386": "i386/alpine:3.6"
+        "aarch64": "arm64v8/alpine:3.7",
+        "amd64": "alpine:3.7",
+        "armhf": "arm32v6/alpine:3.7",
+        "i386": "i386/alpine:3.7"
     },
     "args": {}
 }


### PR DESCRIPTION
# Proposed Changes

Upgrades base image to the latest Alpine linux, 3.7.

## Related Issues

None.