### PR TITLE
🔨Remove edge repo

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -22,10 +22,6 @@ ARG BUILD_ARCH=amd64
 RUN \
     set -o pipefail \
     \
-    && echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories \
-    && echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories \
-    && echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
-    \
     && apk add --no-cache --virtual .build-dependencies \
         tar=1.32-r1 \
     \


### PR DESCRIPTION
# Proposed Changes

None of the community addons rely on the edge repo anymore, due to the issues we have experienced I would suggest that edge should be an opt in.  Thoughts?

## Related Issues

None