### PR TITLE
Upgrade Bashio to v0.10.0

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -52,7 +52,7 @@ RUN \
     && mkdir -p /etc/services.d \
     \
     && curl -J -L -o /tmp/bashio.tar.gz \
-        "https://github.com/hassio-addons/bashio/archive/v0.9.0.tar.gz" \
+        "https://github.com/hassio-addons/bashio/archive/v0.10.0.tar.gz" \
     && mkdir /tmp/bashio \
     && tar zxvf \
         /tmp/bashio.tar.gz \


### PR DESCRIPTION
# Proposed Changes

Upgrades Bashio to v0.10.0

Changelog: <https://github.com/hassio-addons/bashio/releases/tag/v0.10.0>