### PR TITLE
Remove Alpine Linux edge repository support

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -22,10 +22,6 @@ ARG BUILD_ARCH=amd64
 RUN \
     set -o pipefail \
     \
-    && echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories \
-    && echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories \
-    && echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
-    \
     && apk add --no-cache --virtual .build-dependencies \
         tar=1.33-r1 \
     \


### PR DESCRIPTION
# Proposed Changes

Removes support for the Edge repository, as originally suggested by @sinclairpaul in #42

Since that was PR #42, it means it must be the answer to the ultimate question of life, the universe, and everything. So we better apply it.