### PR TITLE
Replace operating system info call in banner

### DIFF
--- a/base/rootfs/etc/cont-init.d/00-banner.sh
+++ b/base/rootfs/etc/cont-init.d/00-banner.sh
@@ -21,7 +21,7 @@ if bashio::supervisor.ping; then
         bashio::log.green ' You are running the latest version of this add-on.'
     fi
 
-    bashio::log.blue " System: $(bashio::host.operating_system)" \
+    bashio::log.blue " System: $(bashio::info.operating_system)" \
         " ($(bashio::info.arch) / $(bashio::info.machine))"
     bashio::log.blue " Home Assistant Core: $(bashio::info.homeassistant)"
     bashio::log.blue " Home Assistant Supervisor: $(bashio::info.supervisor)"


### PR DESCRIPTION
# Proposed Changes

Replaces `bashio::host.operating_sytem` call with `bashio::info.operating_system` call.
Same information, but, as `bashio` caches the already used `info` call, it will be faster on startup.

Furthermore, this removes the need for having access to the Supervisor API in the add-ons for the startup banner, as the info calls don't require authentication.
