### PR TITLE
Upgrade Bashio to v0.10.1

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -48,7 +48,7 @@ RUN \
     && mkdir -p /etc/services.d \
     \
     && curl -J -L -o /tmp/bashio.tar.gz \
-        "https://github.com/hassio-addons/bashio/archive/v0.10.0.tar.gz" \
+        "https://github.com/hassio-addons/bashio/archive/v0.10.1.tar.gz" \
     && mkdir /tmp/bashio \
     && tar zxvf \
         /tmp/bashio.tar.gz \


### PR DESCRIPTION
# Proposed Changes

Bumps Bashio to v0.10.1

Changelog: <https://github.com/hassio-addons/bashio/releases/tag/v0.10.1>
