### PR TITLE
Fix add-on update available check

### DIFF
--- a/base/rootfs/etc/cont-init.d/00-banner.sh
+++ b/base/rootfs/etc/cont-init.d/00-banner.sh
@@ -12,7 +12,7 @@ if bashio::supervisor.ping; then
         '-----------------------------------------------------------'
 
     bashio::log.blue " Add-on version: $(bashio::addon.version)"
-    if bashio::addon.update_available; then
+    if bashio::var.true "$(bashio::addon.update_available)"; then
         bashio::log.magenta ' There is an update available for this add-on!'
         bashio::log.magenta \
             " Latest add-on version: $(bashio::addon.version_latest)"


### PR DESCRIPTION
# Proposed Changes

Fixes an incorrect check to see if a new version of the add-on is available.
The output of this method was changed in Bashio v0.10.0, but the banner was not adjusted to that.

## Related Issues

fixes #67
