### PR TITLE
Upgrade Alpine Linux to 3.13.1

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=alpine:3.13.0
+ARG BUILD_FROM=alpine:3.13.1
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/base/build.json
+++ b/base/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "arm64v8/alpine:3.13.0",
-    "amd64": "amd64/alpine:3.13.0",
-    "armhf": "arm32v6/alpine:3.13.0",
-    "armv7": "arm32v7/alpine:3.13.0",
-    "i386": "i386/alpine:3.13.0"
+    "aarch64": "arm64v8/alpine:3.13.1",
+    "amd64": "amd64/alpine:3.13.1",
+    "armhf": "arm32v6/alpine:3.13.1",
+    "armv7": "arm32v7/alpine:3.13.1",
+    "i386": "i386/alpine:3.13.1"
   }
 }


### PR DESCRIPTION
# Proposed Changes

Upgrades Alpine Linux to 3.13.1

https://www.alpinelinux.org/posts/Alpine-3.13.1-released.html
