### PR TITLE
Upgrade Bashio to v0.13.0

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -48,7 +48,7 @@ RUN \
     && mkdir -p /etc/services.d \
     \
     && curl -J -L -o /tmp/bashio.tar.gz \
-        "https://github.com/hassio-addons/bashio/archive/v0.11.0.tar.gz" \
+        "https://github.com/hassio-addons/bashio/archive/v0.13.0.tar.gz" \
     && mkdir /tmp/bashio \
     && tar zxvf \
         /tmp/bashio.tar.gz \


### PR DESCRIPTION
# Proposed Changes

Upstream release notes:

- <https://github.com/hassio-addons/bashio/releases/tag/v0.13.0>
- <https://github.com/hassio-addons/bashio/releases/tag/v0.12.1>
- <https://github.com/hassio-addons/bashio/releases/tag/v0.12.0>
