### PR TITLE
:arrow_up: Upgrades libssl1.1 to 1.1.1i-r0

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -26,8 +26,8 @@ RUN \
         tar=1.33-r1 \
     \
     && apk add --no-cache \
-        libcrypto1.1=1.1.1i-r0 \
-        libssl1.1=1.1.1i-r0 \
+        libcrypto1.1=1.1.1j-r0 \
+        libssl1.1=1.1.1j-r0 \
         musl-utils=1.2.2-r0 \
         musl=1.2.2-r0 \
     \


### PR DESCRIPTION
# Proposed Changes

Upgrades libssl1.1 to 1.1.1i-r0

- CVE-2021-23841
- CVE-2021-23840
- CVE-2021-23839