### PR TITLE
⬆️ Upgrades libssl1.1 to 1.1.1l-r0

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -26,8 +26,8 @@ RUN \
         tar=1.34-r0 \
     \
     && apk add --no-cache \
-        libcrypto1.1=1.1.1k-r0 \
-        libssl1.1=1.1.1k-r0 \
+        libcrypto1.1=1.1.1l-r0 \
+        libssl1.1=1.1.1l-r0 \
         musl-utils=1.2.2-r3 \
         musl=1.2.2-r3 \
     \


### PR DESCRIPTION
# Proposed Changes

Closing

- [CVE-2021-3711](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3711)
- [CVE-2021-3712](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3712)
