### PR TITLE
Use centralized workflow for lock and stable

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -8,14 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  lock:
-    name: 🔒 Lock closed issues and PRs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: dessant/lock-threads@v3.0.0
-        with:
-          github-token: ${{ github.token }}
-          issue-inactive-days: "30"
-          issue-lock-reason: ""
-          pr-inactive-days: "1"
-          pr-lock-reason: ""
+  workflows:
+    uses: hassio-addons/workflows/.github/workflows/lock.yaml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -8,33 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  stale:
-    name: 🧹 Clean up stale issues and PRs
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🚀 Run stale
-        uses: actions/stale@v4
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 30
-          days-before-close: 7
-          remove-stale-when-updated: true
-          stale-issue-label: "stale"
-          exempt-issue-labels: "no-stale,help-wanted"
-          stale-issue-message: >
-            There hasn't been any activity on this issue recently, so we
-            clean up some of the older and inactive issues.
-
-            Please make sure to update to the latest version and
-            check if that solves the issue. Let us know if that works for you
-            by leaving a comment 👍
-
-            This issue has now been marked as stale and will be closed if no
-            further activity occurs. Thanks!
-          stale-pr-label: "stale"
-          exempt-pr-labels: "no-stale"
-          stale-pr-message: >
-            There hasn't been any activity on this pull request recently. This
-            pull request has been automatically marked as stale because of that
-            and will be closed if no further activity occurs within 7 days.
-            Thank you for your contributions.
+  workflows:
+    uses: hassio-addons/workflows/.github/workflows/stale.yaml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Proposed Changes

Use a centralized workflow for our lock & stable workflows. Giving us a single place to maintain this.
