### PR TITLE
Use centralized workflow for PR labels

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -3,19 +3,15 @@ name: PR Labels
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
+  pull_request_target:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
 
 jobs:
-  pr_labels:
-    name: Verify
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🏷 Verify PR has a valid label
-        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          valid-labels: >-
-            breaking-change, bugfix, documentation, enhancement, refactor,
-            performance, new-feature, maintenance, ci, dependencies
-          disable-reviews: true
+  workflows:
+    uses: hassio-addons/workflows/.github/workflows/pr-labels.yaml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Proposed Changes

Use centralized workflow for PR labels, allowing us to maintain only 1 instance
