### PR TITLE
Downgrade tempio to 2021.09.0 (as .10 doesn't exists)

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -58,7 +58,7 @@ RUN \
     && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
     \
     && curl -L -s -o /usr/bin/tempio \
-        "https://github.com/home-assistant/tempio/releases/download/2021.10.0/tempio_${BUILD_ARCH}" \
+        "https://github.com/home-assistant/tempio/releases/download/2021.09.0/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     \
     && apk del --no-cache --purge .build-dependencies \


### PR DESCRIPTION
# Proposed Changes

Something wen wrong here, .10 doesn't exists... 🙈 