### PR TITLE
⬆️ Upgrades Bashio to v0.14.2

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -48,7 +48,7 @@ RUN \
     && mkdir -p /etc/services.d \
     \
     && curl -J -L -o /tmp/bashio.tar.gz \
-        "https://github.com/hassio-addons/bashio/archive/v0.14.1.tar.gz" \
+        "https://github.com/hassio-addons/bashio/archive/v0.14.2.tar.gz" \
     && mkdir /tmp/bashio \
     && tar zxvf \
         /tmp/bashio.tar.gz \


### PR DESCRIPTION
# Proposed Changes

Upgrades Bashio to v0.14.2

https://github.com/hassio-addons/bashio/releases/tag/v0.14.2