### PR TITLE
⬆️ Upgrades libssl1.1 to 1.1.1n-r0

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -26,8 +26,8 @@ RUN \
         tar=1.34-r0 \
     \
     && apk add --no-cache \
-        libcrypto1.1=1.1.1l-r8 \
-        libssl1.1=1.1.1l-r8 \
+        libcrypto1.1=1.1.1n-r0 \
+        libssl1.1=1.1.1n-r0 \
         musl-utils=1.2.2-r7 \
         musl=1.2.2-r7 \
     \


### PR DESCRIPTION
# Proposed Changes

Upgrades libssl1.1 to 1.1.1n-r0

Addressing CVE-2022-0778