### PR TITLE
⬆️ Upgrades Alpine Linux to 3.15.4

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=alpine:3.15.1
+ARG BUILD_FROM=alpine:3.15.4
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/base/build.yaml
+++ b/base/build.yaml
@@ -1,9 +1,9 @@
 ---
 build_from:
-  aarch64: arm64v8/alpine:3.15.1
-  amd64: amd64/alpine:3.15.1
-  armhf: arm32v6/alpine:3.15.1
-  armv7: arm32v7/alpine:3.15.1
-  i386: i386/alpine:3.15.1
+  aarch64: arm64v8/alpine:3.15.4
+  amd64: amd64/alpine:3.15.4
+  armhf: arm32v6/alpine:3.15.4
+  armv7: arm32v7/alpine:3.15.4
+  i386: i386/alpine:3.15.4
 codenotary:
   signer: codenotary@frenck.dev


### PR DESCRIPTION
# Proposed Changes

Upgrade Apline Linux to 3.15.4.  This addresses several high and a critical CVE.

https://alpinelinux.org/posts/Alpine-3.12.12-3.13.10-3.14.6-3.15.4-released.html
