### PR TITLE
Provide more defaults

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -4,13 +4,21 @@ FROM ${BUILD_FROM}
 
 # Environment variables
 ENV \
+    CARGO_NET_GIT_FETCH_WITH_CLI=true \
     HOME="/root" \
     LANG="C.UTF-8" \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_FIND_LINKS=https://wheels.home-assistant.io/musllinux/ \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_PREFER_BINARY=1 \
     PS1="$(whoami)@$(hostname):$(pwd)$ " \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
     S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
-    S6_CMD_WAIT_FOR_SERVICES=1 \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
-    TERM="xterm-256color"
+    S6_CMD_WAIT_FOR_SERVICES=1 \
+    YARN_HTTP_TIMEOUT=1000000 \
+    TERM="xterm-256color" 
 
 # Copy root filesystem
 COPY rootfs /


### PR DESCRIPTION
# Proposed Changes

This PR adds a bunch of defaults for several applications, making images downstream easier, smaller and more consistent.

- Use `git` to fetch from Cargo index; It most often hangs or runs out of memory on GitHub Actions otherwise.
- Several Python tweaks:
  - Don't check for `pip` versions. The end-user can do shit about it.
  - Use the Python Wheel index of Home Assistant for additional wheels. Home Assistant pre-builds musl-based wheels for Alpine. Makes building with python faster.
  - Don't use a cache dir in `pip`.
  - Prefer binary distributions in `pip`.
  - Don't write bytecode. Add-ons don't have a persistent state, thus any bytecode written will be gone after restart anyways; saving I/O.
  - Let Python output logs unbuffered, to make Docker logs a little more useful.
- Set a bigger YARN timeout. Yarn has the nasty habit to hang for a bit, so this allows for that (instead of the build failing time and time again).
