### PR TITLE
Add tiny legacy s6 disable script

### DIFF
--- a/base/rootfs/usr/bin/base-no-legacy-s6-overlay
+++ b/base/rootfs/usr/bin/base-no-legacy-s6-overlay
@@ -1,0 +1,11 @@
+#!/bin/bash
+# ==============================================================================
+# Home Assistant Community Add-on: Base Images
+# Really tiny command, that can be used by other images to remove legacy S6
+# Overlay files. This makes startup for those add-ons a tiny bit cleaner.
+# ==============================================================================
+rm -fr \
+  /package/admin/s6-overlay/etc/s6-rc/sources/base/contents.d/legacy-cont-init \
+  /package/admin/s6-overlay/etc/s6-rc/sources/top/contents.d/legacy-services \
+  /package/admin/s6-overlay/etc/s6-rc/sources/legacy-cont-init \
+  /package/admin/s6-overlay/etc/s6-rc/sources/legacy-services


### PR DESCRIPTION
# Proposed Changes

Adds a tiny little script that an add-on can call during the build, to indicate they are not using legacy s6-rc services.

This script will then clean up those, making the start-up a little smaller (as otherwise, s6-overlay will always try to handle legacy).

