### PR TITLE
Fix superfluous v in s6-overlay versioning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,8 @@
       ],
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "loose",
-      "depNameTemplate": "just-containers/s6-overlay"
+      "depNameTemplate": "just-containers/s6-overlay",
+      "extractVersion": "^v(?<version>.*)$"
     },
     {
       "fileMatch": ["/Dockerfile$"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,7 +33,7 @@
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "loose",
       "depNameTemplate": "just-containers/s6-overlay",
-      "extractVersion": "^v(?<version>.*)$"
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "fileMatch": ["/Dockerfile$"],

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -52,16 +52,16 @@ RUN \
     elif [ "${BUILD_ARCH}" = "amd64" ]; then S6_ARCH="x86_64"; \
     elif [ "${BUILD_ARCH}" = "armv7" ]; then S6_ARCH="arm"; fi \
     \
-    && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
         | tar -C / -Jxpf - \
     \
-    && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
         | tar -C / -Jxpf - \
     \
-    && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
         | tar -C / -Jxpf - \
     \
-    && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
         | tar -C / -Jxpf - \
     \
     && curl -J -L -o /tmp/bashio.tar.gz \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -86,7 +86,7 @@ RUN \
 COPY rootfs /
 
 # Copy s6-overlay adjustments
-COPY s6-overlay /package/admin/s6-overlay-${S6_OVERLAY_VERSION}/
+COPY s6-overlay /package/admin/s6-overlay-${S6_OVERLAY_VERSION#v}/
 
 # Entrypoint & CMD
 ENTRYPOINT ["/init"]

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -26,7 +26,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # Install base system
 ARG BUILD_ARCH=amd64
 ARG BASHIO_VERSION="v0.14.3"
-ARG S6_OVERLAY_VERSION="v3.1.4.1"
+ARG S6_OVERLAY_VERSION="3.1.4.1"
 ARG TEMPIO_VERSION="2021.09.0"
 RUN \
     set -o pipefail \
@@ -86,7 +86,7 @@ RUN \
 COPY rootfs /
 
 # Copy s6-overlay adjustments
-COPY s6-overlay /package/admin/s6-overlay-${S6_OVERLAY_VERSION#v}/
+COPY s6-overlay /package/admin/s6-overlay-${S6_OVERLAY_VERSION}/
 
 # Entrypoint & CMD
 ENTRYPOINT ["/init"]


### PR DESCRIPTION
# Proposed Changes

In PR #217 (note the character **v**)
```diff
-ARG S6_OVERLAY_VERSION="3.1.4.0"
+ARG S6_OVERLAY_VERSION="v3.1.4.0"
```
But this hasn't changed:
```
COPY s6-overlay /package/admin/s6-overlay-${S6_OVERLAY_VERSION}/
```
No we've got this:
```
$ls -liag /package/admin/s6-overlay-3.1.4.1/etc/s6-rc/scripts/
 407304 drwxr-xr-x    2 root          4096 Mar 15 17:12 .
 407303 drwxr-xr-x    4 root          4096 Mar 15 17:09 ..
 407305 -rwxr-xr-x    1 root           574 Mar 15 17:12 cont-finish
 407306 -rwxr-xr-x    1 root           812 Mar 15 17:12 cont-init
 407307 -rwxr-xr-x    1 root           922 Mar 15 17:12 fix-attrs
 407308 -rwxr-xr-x    1 root           457 Mar 15 17:12 services-down
 407309 -rwxr-xr-x    1 root          1935 Mar 15 17:12 services-up
$ ls -liag /package/admin/s6-overlay-v3.1.4.1/etc/s6-rc/scripts/
 408762 drwxr-xr-x    2 root          4096 Mar 28 19:26 .
 408761 drwxr-xr-x    4 root          4096 Mar 28 19:26 ..
 408763 -rwxr-xr-x    1 root          1772 Mar 28 19:26 base-addon-banner
 408764 -rwxr-xr-x    1 root          1567 Mar 28 19:26 base-addon-log-level
```

---

**This modification is not tested!!! But can't think of any other cause for this issue.**

---

## Related Issues

PR #217