### PR TITLE
Do not end LOG_LEVEL environment variable with newline (set by base-addon-log-level script)

### DIFF
--- a/base/s6-overlay/etc/s6-rc/scripts/base-addon-log-level
+++ b/base/s6-overlay/etc/s6-rc/scripts/base-addon-log-level
@@ -44,6 +44,6 @@ if bashio::config.exists log_level; then
     esac
 
     # Save determined log level so S6 can pick it up later
-    echo "${log_level}" > /var/run/s6/container_environment/LOG_LEVEL
+    echo -n "${log_level}" > /var/run/s6/container_environment/LOG_LEVEL
     bashio::log.blue "Log level is set to ${__BASHIO_LOG_LEVELS[$log_level]}"
 fi


### PR DESCRIPTION
# Proposed Changes

None of the variables in `/var/run/s6/container_environment` contains a newline at the end, only the `LOG_LEVEL` when set by the `base-addon-log-level` script.

The newline breaks code like `"${__BASHIO_LOG_LEVELS[${__BASHIO_LOG_LEVEL}],,}"`

## Related Issues

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
