### PR TITLE
Fix renovate configuration pointing to incorrect Alpine Linux release

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -52,7 +52,7 @@
       ],
       "versioningTemplate": "loose",
       "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_19/{{package}}"
+      "depNameTemplate": "alpine_3_20/{{package}}"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
# Proposed Changes

SSIA, it was still pointing to 3.19, while the base image is already on 3.20