### PR TITLE
⬆️ Update hassio-addons/bashio to v0.17.4

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -19,14 +19,14 @@ ENV \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
     S6_CMD_WAIT_FOR_SERVICES=1 \
     YARN_HTTP_TIMEOUT=1000000 \
-    TERM="xterm-256color" 
+    TERM="xterm-256color"
 
 # Set shell
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Install base system
 ARG BUILD_ARCH=amd64
-ARG BASHIO_VERSION="v0.17.3"
+ARG BASHIO_VERSION="v0.17.4"
 ARG S6_OVERLAY_VERSION="3.2.1.0"
 ARG TEMPIO_VERSION="2024.11.2"
 RUN \


### PR DESCRIPTION
# Proposed Changes

Right now the base container simply crashes, because of the linked issue/fix.

## Related Issues

https://github.com/hassio-addons/bashio/pull/173

```
s6-rc: info: service base-addon-banner: starting
/usr/lib/bashio/log.sh: line 11: LOG_FD: unbound variable
s6-rc: warning: unable to start service base-addon-banner: command exited 1
/run/s6/basedir/scripts/rc.init: warning: s6-rc failed to properly bring all the services up! Check your logs (in /run/uncaught-logs/current if you have in-container logging) for more information.
/run/s6/basedir/scripts/rc.init: fatal: stopping the container.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the Bashio runtime to v0.17.4, bringing in the latest security patches and minor bug fixes for the container base environment.
  - Improves build consistency, compatibility, and overall stability.
  - No user-facing changes or behavioral differences are expected as a result of this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->