### PR TITLE
Use correct Alpine version in Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,7 +58,7 @@
       ],
       "versioningTemplate": "loose",
       "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_22/{{package}}"
+      "depNameTemplate": "alpine_3_23/{{package}}"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
# Proposed Changes

It was not updated last time, unfortunately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Alpine base image version reference in dependency management configuration from version 3.22 to 3.23.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->