### PR TITLE
Update BASHIO_VERSION to the installed version

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -19,7 +19,7 @@ ENV \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
     S6_CMD_WAIT_FOR_SERVICES=1 \
     YARN_HTTP_TIMEOUT=1000000 \
-    TERM="xterm-256color" 
+    TERM="xterm-256color"
 
 # Set shell
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
@@ -72,6 +72,7 @@ RUN \
     \
     && mv /tmp/bashio/lib /usr/lib/bashio \
     && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
+    && sed -i "s/readonly BASHIO_VERSION=\"[^\"]*\"/readonly BASHIO_VERSION=\"${BASHIO_VERSION#v}\"/" /usr/lib/bashio/bashio.sh \
     \
     && curl -L -s -o /usr/bin/tempio \
         "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \


### PR DESCRIPTION
# Proposed Changes

BASHIO_VERSION is currently constant "0.1.0", this updates it to the installed version.

If merged, these should be changed also:
- https://github.com/hassio-addons/app-debian-base/blob/main/base/Dockerfile
- https://github.com/hassio-addons/addon-ubuntu-base/blob/main/base/Dockerfile

## Related Issues

fixes https://github.com/hassio-addons/bashio/issues/193


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration and version handling logic.

* **Style**
  * Removed trailing whitespace from environment variable declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->