### PR TITLE
In the banner, use bashio::app functions instead of the deprecated bashio::addon functions

### DIFF
--- a/base/s6-overlay/etc/s6-rc/scripts/base-addon-banner
+++ b/base/s6-overlay/etc/s6-rc/scripts/base-addon-banner
@@ -7,16 +7,16 @@
 if bashio::supervisor.ping; then
     bashio::log.blue \
         '-----------------------------------------------------------'
-    bashio::log.blue " App: $(bashio::addon.name)"
-    bashio::log.blue " $(bashio::addon.description)"
+    bashio::log.blue " App: $(bashio::app.name)"
+    bashio::log.blue " $(bashio::app.description)"
     bashio::log.blue \
         '-----------------------------------------------------------'
 
-    bashio::log.blue " App version: $(bashio::addon.version)"
-    if bashio::var.true "$(bashio::addon.update_available)"; then
+    bashio::log.blue " App version: $(bashio::app.version)"
+    if bashio::var.true "$(bashio::app.update_available)"; then
         bashio::log.magenta ' There is an update available for this app!'
         bashio::log.magenta \
-            " Latest app version: $(bashio::addon.version_latest)"
+            " Latest app version: $(bashio::app.version_latest)"
         bashio::log.magenta ' Please consider upgrading as soon as possible.'
     else
         bashio::log.green ' You are running the latest version of this app.'


### PR DESCRIPTION
# Proposed Changes

SSIA

Currently I get a lot of warnings on startup:
```
2026/06/09 22:58:49 WARNING: bashio::addon.name is deprecated, use bashio::app.name instead.
```

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the startup banner to refresh how application metadata is retrieved and displayed, including name, description, version, and update information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->